### PR TITLE
ENG-715 Changing annotation for crop ratio

### DIFF
--- a/src/main/java/org/entando/entando/plugins/jacms/web/contentsettings/model/ContentSettingsCropRatioRequest.java
+++ b/src/main/java/org/entando/entando/plugins/jacms/web/contentsettings/model/ContentSettingsCropRatioRequest.java
@@ -1,13 +1,12 @@
 package org.entando.entando.plugins.jacms.web.contentsettings.model;
 
+import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
-
-import javax.validation.constraints.NotEmpty;
 
 @Getter@Setter
 public class ContentSettingsCropRatioRequest {
 
-    @NotEmpty
+    @NotNull
     private String ratio;
 }


### PR DESCRIPTION
We were using the annotation: `javax.validation.constraints.NotEmpty`
When we actually use: `org.hibernate.validator.constraints.NotEmpty` which is deprecated
To fix this problem and keep the same pattern with the other similar String fields in CMS I changed it to: `javax.validation.constraints.NotNull`

Here are some stackoverflow questions about the same problem:
[Stackoverflow question 1](https://stackoverflow.com/questions/52608600/hv000030-no-validator-could-be-found-for-constraint-javax-validation-constrai/56096275)
[Stackoverflow question 2](https://stackoverflow.com/questions/5982741/validation-error-no-validator-could-be-found-for-type-java-lang-integer)