### PR TITLE
ENG-3393 Fixed issue caused by null value in content filters

### DIFF
--- a/src/main/java/com/agiletec/plugins/jacms/apsadmin/content/ContentFinderAction.java
+++ b/src/main/java/com/agiletec/plugins/jacms/apsadmin/content/ContentFinderAction.java
@@ -196,6 +196,7 @@ public class ContentFinderAction extends AbstractApsEntityFinderAction {
                 searchInfo = new ContentFinderSearchInfo();
                 this.getRequest().getSession().setAttribute(ContentFinderSearchInfo.SESSION_NAME, searchInfo);
             }
+            this.createFilters();
             this.restoreCommonSearchState(searchInfo);
             this.restoreCategorySearchState(searchInfo);
             this.restoreEntitySearchState(searchInfo);

--- a/src/test/java/com/agiletec/plugins/jacms/apsadmin/content/TestContentFinderAction.java
+++ b/src/test/java/com/agiletec/plugins/jacms/apsadmin/content/TestContentFinderAction.java
@@ -353,7 +353,17 @@ class TestContentFinderAction extends AbstractBaseTestContentAction {
 		contents = action.getContents();
 		assertEquals(0, contents.size());
 	}
-	
+
+	@Test
+	void testGetPaginatedContentsIdAfterLoadingResults() throws Throwable {
+		this.initAction("/do/jacms/Content", "results");
+		this.setUserOnSession("admin");
+		String result = this.executeAction();
+		assertEquals(Action.SUCCESS, result);
+		ContentFinderAction action = (ContentFinderAction) this.getAction();
+		action.getPaginatedContentsId(10);
+	}
+
 	private void executeSearch(String currentUserName, Map<String, String> params) throws Throwable {
 		this.initAction("/do/jacms/Content", "search");
 		this.setUserOnSession(currentUserName);


### PR DESCRIPTION
If the list of contents was never loaded by the admin-console (for example when creating a content starting from the app-builder), then the search filters were not initialized, causing an error after the saving of content.